### PR TITLE
Add embedded version of xhyve-ruby first on the LOAD_PATH and bumped version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.1 (December 8th, 2016)
+
+* Put the embedded version of xhyve-ruby first in the LOAD_PATH (Guy Pascarella)
+
 # 0.3.0 (December 5th, 2016)
 
 * Added `kernel_command` option to set custom kernel parameters (Nuno Passaro)

--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ $ bundle exec vagrant up --provider=xhyve
 
 * Patrick Armstrong
 * Nuno Passaro
+* Guy Pascarella

--- a/lib/vagrant-xhyve.rb
+++ b/lib/vagrant-xhyve.rb
@@ -8,6 +8,10 @@ module VagrantPlugins
     autoload :Action, lib_path.join("action")
     autoload :Errors, lib_path.join("errors")
 
+	# Put vagrant-xhyve-x.y.z/vendor/xhyve-ruby/lib on the LOAD_PATH before
+	# the auto-loaded xhyve-ruby-a.b.c
+	$LOAD_PATH.unshift(Pathname.new(File.expand_path("../../vendor/xhyve-ruby/lib", __FILE__)))
+
     # This returns the path to the source of this plugin.
     #
     # @return [Pathname]

--- a/lib/vagrant-xhyve/version.rb
+++ b/lib/vagrant-xhyve/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module XHYVE
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end


### PR DESCRIPTION
It looks like `xhyve-ruby` won't release a new version anytime soon due to Travis CI's inability to use EPT (and thus xhyve) on a build agent. Therefore this pull request defers to the embedded version of `xhyve-ruby` in the vendor directory via `LOAD_PATH` manipulation. This should address issue #5 and allow out of the box usage of the plugin.