### PR TITLE
Changes to replace kexec for vmtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This provider exposes quite a few provider-specific configuration options:
 * `cpus` - The number of CPUs to give the VM
 * `xhyve_binary` - use a custom xhyve version
 * kernel_command - send a custom kernel boot command
+* `vmtype` - The type of VM (kexec or fbsd) 
 
 These can be set like typical provider-specific configuration:
 
@@ -78,6 +79,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :xhyve do |xhyve|
     xhyve.cpus = 2
     xhyve.memory = "1G"
+    xhyve.vmtype = "kexec"
     xhyve.xhyve_binary = "/Applications/Docker.app/Contents/MacOS/com.docker.hyperkit"
     xhyve.kernel_command = "root=/dev/mapper/centos-root ro crashkernel=auto rd.lvm.lv=centos/root rd.lvm.lv=centos/swap acpi=off console=ttyS0 LANG=en_GB.UTF-8" # example for a CentOS installed in a LVM filesystem
   end

--- a/lib/vagrant-xhyve/config.rb
+++ b/lib/vagrant-xhyve/config.rb
@@ -20,6 +20,13 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :memory
 
+      # The type of VM that is going to run
+      #
+      # The two posible types are: kexec or fbsd
+      # kexec -> linux
+      # fbsd -> FreeBSD
+      attr_accessor :vmtype
+
 
       # The path to the xhyve binary if you don't want to
       # use the one bundled with xhyve-ruby
@@ -47,6 +54,7 @@ module VagrantPlugins
       def initialize(region_specific=false)
         @cpus           = UNSET_VALUE
         @memory         = UNSET_VALUE
+        @vmtype         = UNSER_VALUE
         @xhyve_binary   = UNSET_VALUE
         @mac            = UNSET_VALUE
         @uuid           = UNSET_VALUE
@@ -68,6 +76,7 @@ module VagrantPlugins
 
         @cpus = 1 if @cpus == UNSET_VALUE
         @memory = 1024 if @memory == UNSET_VALUE
+        @vmtype = "kexec" if @vmtype == UNSET_VALUE
         @xhyve_binary = nil if @xhyve_binary == UNSET_VALUE
         @kernel_command = %Q{"earlyprintk=serial console=ttyS0 root=/dev/vda1 ro"} if @kernel_command == UNSET_VALUE
         # Mark that we finalized

--- a/lib/vagrant-xhyve/config.rb
+++ b/lib/vagrant-xhyve/config.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
       def initialize(region_specific=false)
         @cpus           = UNSET_VALUE
         @memory         = UNSET_VALUE
-        @vmtype         = UNSER_VALUE
+        @vmtype         = UNSET_VALUE
         @xhyve_binary   = UNSET_VALUE
         @mac            = UNSET_VALUE
         @uuid           = UNSET_VALUE

--- a/lib/vagrant-xhyve/util/vagrant-xhyve.rb
+++ b/lib/vagrant-xhyve/util/vagrant-xhyve.rb
@@ -36,6 +36,7 @@ module VagrantPlugins
             :mac => @mac,
             :ip => ip,
             :binary => @binary
+            :vmtype => @vmtype
           }
         end
 
@@ -51,7 +52,7 @@ module VagrantPlugins
             "#{build_block_device_parameter}",
             '-s', '31,lpc',
             '-l', "#{@serial},stdio",
-            '-f', "kexec,#{@kernel},#{@initrd},'#{@cmdline}'"
+            '-f', "#{@vmtype},#{@kernel},#{@initrd},'#{@cmdline}'"
           ].join(' ')
         end
 

--- a/vendor/xhyve-ruby/lib/xhyve/guest.rb
+++ b/vendor/xhyve-ruby/lib/xhyve/guest.rb
@@ -30,6 +30,7 @@ module Xhyve
       @binary = opts[:binary] || BINARY_PATH
       @command = build_command
       @mac = find_mac
+      @vmtype = opts[:vmtype] || 'kexec'
     end
 
     def start
@@ -81,7 +82,7 @@ module Xhyve
         "#{"#{@blockdevs.each_with_index.map { |p, i| "-s #{PCI_BASE + i},virtio-blk,#{p}" }.join(' ')}" unless @blockdevs.empty? }",
         '-s', '31,lpc',
         '-l', "#{@serial},stdio",
-        '-f' "kexec,#{@kernel},#{@initrd},'#{@cmdline}'"
+        '-f' "#{@vmtype},#{@kernel},#{@initrd},'#{@cmdline}'"
       ].join(' ')
     end
   end


### PR DESCRIPTION
This change will allow the driver to run fbsd machines too by removing the hard coded kexec from the code and replacing it with a variable called vmtype.
